### PR TITLE
Add `localhost:3000` to access control

### DIFF
--- a/backend/search_api_endpoint.py
+++ b/backend/search_api_endpoint.py
@@ -33,6 +33,7 @@ origins = [
     "http://localhost",
     "http://localhost:8080",
     "http://localhost:8000",
+    "http://localhost:3000",
 ]
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
I had to make this update in order to get the backend running with a development environment of the [`epiverse-search-frontend`](https://github.com/epiverse-connect/epiverse-search-frontend).


